### PR TITLE
[0.8.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-postgres/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-postgres)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/CI%20Master/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/CI%20Master/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     jacocoAggregation project(":kafka")
     jacocoAggregation project(":cassandra")
     jacocoAggregation project(":redis")
+    jacocoAggregation project(":mockserver")
 }
 
 reporting {

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-cassandra:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-cassandra:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-cassandra:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-cassandra</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/cassandra/README.md
+++ b/cassandra/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-cassandra/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-cassandra)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -64,7 +64,7 @@ testImplementation "com.datastax.oss:java-driver-core:4.17.0"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/cassandra/src/main/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraConnection.java
+++ b/cassandra/src/main/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraConnection.java
@@ -58,6 +58,8 @@ public interface CassandraConnection {
     Optional<Params> paramsInNetwork();
 
     /**
+     * NOTE: DO NOT CLOSE CONNECTION
+     *
      * @return new Cassandra connection
      */
     @NotNull

--- a/cassandra/src/main/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraConnectionImpl.java
+++ b/cassandra/src/main/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraConnectionImpl.java
@@ -124,19 +124,22 @@ final class CassandraConnectionImpl implements CassandraConnection {
 
     @NotNull
     public CqlSession get() {
-        return connection;
+        return connection();
     }
 
     @NotNull
     private CqlSession connection() {
         if (connection == null) {
-            connection = open();
+            connection = openConnection();
+        } else if (connection.isClosed()) {
+            connection = openConnection();
         }
+
         return connection;
     }
 
     @NotNull
-    private CqlSession open() {
+    private CqlSession openConnection() {
         logger.debug("Opening CQL connection...");
 
         var config = new DefaultProgrammaticDriverConfigLoaderBuilder()

--- a/cassandra/src/main/java/io/goodforgod/testcontainers/extensions/cassandra/TestcontainersCassandraExtension.java
+++ b/cassandra/src/main/java/io/goodforgod/testcontainers/extensions/cassandra/TestcontainersCassandraExtension.java
@@ -1,6 +1,7 @@
 package io.goodforgod.testcontainers.extensions.cassandra;
 
 import io.goodforgod.testcontainers.extensions.AbstractTestcontainersExtension;
+import io.goodforgod.testcontainers.extensions.ContainerMode;
 import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
@@ -12,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.CassandraContainer;
@@ -211,19 +213,29 @@ class TestcontainersCassandraExtension extends
         super.beforeAll(context);
 
         var metadata = getMetadata(context);
-        var connectionCurrent = getConnectionCurrent(context);
-        if (metadata.migration().apply() == Migration.Mode.PER_CLASS) {
+        if (metadata.migration().apply() != Migration.Mode.NONE) {
+            var storage = getStorage(context);
+            var connectionCurrent = getConnectionCurrent(context);
             tryMigrateIfRequired(metadata, connectionCurrent);
+            storage.put(Migration.class, metadata.migration().apply());
         }
     }
 
     @Override
     public void beforeEach(ExtensionContext context) {
+        var metadata = getMetadata(context);
+        if (metadata.runMode() == ContainerMode.PER_METHOD && metadata.migration().apply() == Migration.Mode.PER_CLASS) {
+            throw new ExtensionConfigurationException(String.format(
+                    "@%s can't apply migration in Migration.Mode.PER_CLASS mode when ContainerMode.PER_METHOD is used",
+                    getContainerAnnotation().getSimpleName()));
+        }
+
         super.beforeEach(context);
 
-        var metadata = getMetadata(context);
-        var connectionCurrent = getConnectionCurrent(context);
-        if (metadata.migration().apply() == Migration.Mode.PER_METHOD) {
+        var storage = getStorage(context);
+        var mode = storage.get(Migration.class, Migration.Mode.class);
+        if (mode == null) {
+            var connectionCurrent = getConnectionCurrent(context);
             tryMigrateIfRequired(metadata, connectionCurrent);
         }
     }
@@ -231,9 +243,18 @@ class TestcontainersCassandraExtension extends
     @Override
     public void afterEach(ExtensionContext context) {
         var metadata = getMetadata(context);
-        var connectionCurrent = getConnectionCurrent(context);
+        var storage = getStorage(context);
+        storage.remove(Migration.class);
         if (metadata.migration().drop() == Migration.Mode.PER_METHOD) {
-            tryDropIfRequired(metadata, connectionCurrent);
+            if (metadata.runMode() != ContainerMode.PER_METHOD) {
+                var connectionCurrent = getConnectionCurrent(context);
+                tryDropIfRequired(metadata, connectionCurrent);
+            }
+        }
+
+        var connectionCurrent = getConnectionCurrent(context);
+        if (metadata.runMode() == ContainerMode.PER_METHOD) {
+            ((CassandraConnectionImpl) connectionCurrent).close();
         }
 
         super.afterEach(context);
@@ -244,7 +265,13 @@ class TestcontainersCassandraExtension extends
         var metadata = getMetadata(context);
         var connectionCurrent = getConnectionCurrent(context);
         if (metadata.migration().drop() == Migration.Mode.PER_CLASS) {
-            tryDropIfRequired(metadata, connectionCurrent);
+            if (metadata.runMode() == ContainerMode.PER_RUN) {
+                tryDropIfRequired(metadata, connectionCurrent);
+            }
+        }
+
+        if (metadata.runMode() == ContainerMode.PER_CLASS) {
+            ((CassandraConnectionImpl) connectionCurrent).close();
         }
 
         super.afterAll(context);

--- a/cassandra/src/test/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraConnectionAssertsTests.java
+++ b/cassandra/src/test/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraConnectionAssertsTests.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.opentest4j.AssertionFailedError;
 
 @TestcontainersCassandra(mode = ContainerMode.PER_CLASS,
-        image = "cassandra:4.1",
         migration = @Migration(
                 engine = Migration.Engines.SCRIPTS,
                 apply = Migration.Mode.PER_METHOD,

--- a/cassandra/src/test/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraSimplePerClassMigrationTests.java
+++ b/cassandra/src/test/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraSimplePerClassMigrationTests.java
@@ -1,15 +1,12 @@
 package io.goodforgod.testcontainers.extensions.cassandra;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.goodforgod.testcontainers.extensions.ContainerMode;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 
 @TestcontainersCassandra(mode = ContainerMode.PER_CLASS,
-        image = "cassandra:4.1",
         migration = @Migration(
                 engine = Migration.Engines.SCRIPTS,
                 apply = Migration.Mode.PER_CLASS,
@@ -17,6 +14,18 @@ import org.junit.jupiter.api.TestMethodOrder;
                 migrations = { "migration" }))
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CassandraSimplePerClassMigrationTests {
+
+    @BeforeAll
+    public static void setupAll(@ContainerCassandraConnection CassandraConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM cassandra.users;", r -> r.getInt(0));
+        assertNotNull(paramConnection);
+    }
+
+    @BeforeEach
+    public void setupEach(@ContainerCassandraConnection CassandraConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM cassandra.users;", r -> r.getInt(0));
+        assertNotNull(paramConnection);
+    }
 
     @Order(1)
     @Test

--- a/cassandra/src/test/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraSimplePerMethodMigrationTests.java
+++ b/cassandra/src/test/java/io/goodforgod/testcontainers/extensions/cassandra/CassandraSimplePerMethodMigrationTests.java
@@ -1,15 +1,12 @@
 package io.goodforgod.testcontainers.extensions.cassandra;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.goodforgod.testcontainers.extensions.ContainerMode;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 
 @TestcontainersCassandra(mode = ContainerMode.PER_CLASS,
-        image = "cassandra:4.1",
         migration = @Migration(
                 engine = Migration.Engines.SCRIPTS,
                 apply = Migration.Mode.PER_METHOD,
@@ -17,6 +14,12 @@ import org.junit.jupiter.api.TestMethodOrder;
                 migrations = { "migration" }))
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class CassandraSimplePerMethodMigrationTests {
+
+    @BeforeEach
+    public void setupEach(@ContainerCassandraConnection CassandraConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM cassandra.users;", r -> r.getInt(0));
+        assertNotNull(paramConnection);
+    }
 
     @Order(1)
     @Test

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-cockroachdb/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-cockroachdb)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -63,7 +63,7 @@ testRuntimeOnly "org.postgresql:postgresql:42.6.0"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/cockroachdb/README.md
+++ b/cockroachdb/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-cockroachdb:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-cockroachdb:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-cockroachdb:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-cockroachdb</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/common/README.md
+++ b/common/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-common/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-common)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)

--- a/common/src/main/java/io/goodforgod/testcontainers/extensions/AbstractTestcontainersExtension.java
+++ b/common/src/main/java/io/goodforgod/testcontainers/extensions/AbstractTestcontainersExtension.java
@@ -3,12 +3,16 @@ package io.goodforgod.testcontainers.extensions;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.*;
 import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -26,13 +30,45 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
         AfterEachCallback,
         ParameterResolver {
 
-    static final class SharedKey {
+    public enum CallMode {
+        CONSTRUCTOR,
+        BEFORE_EACH,
+        BEFORE_ALL,
+    }
+
+    interface SharedKey {}
+
+    static final class SharedContainerInstance implements SharedKey {
+
+        private final GenericContainer<?> container;
+
+        public SharedContainerInstance(GenericContainer<?> container) {
+            this.container = container;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o)
+                return true;
+            if (o == null || getClass() != o.getClass())
+                return false;
+            SharedContainerInstance sharedKey = (SharedContainerInstance) o;
+            return container == sharedKey.container;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(container);
+        }
+    }
+
+    static final class SharedContainerKey implements SharedKey {
 
         private final String image;
         private final boolean network;
         private final String alias;
 
-        SharedKey(String image, boolean network, String alias) {
+        SharedContainerKey(String image, boolean network, String alias) {
             this.image = image;
             this.network = network;
             this.alias = alias;
@@ -48,7 +84,7 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
                 return true;
             if (o == null || getClass() != o.getClass())
                 return false;
-            SharedKey sharedKey = (SharedKey) o;
+            SharedContainerKey sharedKey = (SharedContainerKey) o;
             return network == sharedKey.network && Objects.equals(image, sharedKey.image)
                     && Objects.equals(alias, sharedKey.alias);
         }
@@ -129,7 +165,7 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
     protected <T extends Annotation> Optional<T> findAnnotation(Class<T> annotationType, ExtensionContext context) {
         Optional<ExtensionContext> current = Optional.of(context);
         while (current.isPresent()) {
-            var requiredClass = current.get().getRequiredTestClass();
+            Class<?> requiredClass = current.get().getRequiredTestClass();
             while (!requiredClass.equals(Object.class)) {
                 final Optional<T> annotation = AnnotationSupport.findAnnotation(requiredClass, annotationType);
                 if (annotation.isPresent()) {
@@ -182,8 +218,8 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
     }
 
     protected void injectConnection(Connection connection, ExtensionContext context) {
-        var connectionAnnotation = getConnectionAnnotation();
-        var connectionFields = ReflectionUtils.findFields(context.getRequiredTestClass(),
+        Class<? extends Annotation> connectionAnnotation = getConnectionAnnotation();
+        List<Field> connectionFields = ReflectionUtils.findFields(context.getRequiredTestClass(),
                 f -> !f.isSynthetic()
                         && !Modifier.isFinal(f.getModifiers())
                         && !Modifier.isStatic(f.getModifiers())
@@ -214,7 +250,7 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
         }
 
         if (!parameterContext.getParameter().getType().equals(getConnectionType())) {
-            throw new ExtensionConfigurationException(String.format("Parameter '%s' annotated @%s is not of type %s",
+            throw new ParameterResolutionException(String.format("Parameter '%s' annotated @%s is not of type %s",
                     parameterContext.getParameter().getName(), connectionAnnotation.getSimpleName(),
                     getConnectionType()));
         }
@@ -225,61 +261,92 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
     @Override
     public Object resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
             throws ParameterResolutionException {
-        var externalConnection = getConnectionExternalCached();
+        Connection externalConnection = getConnectionExternalCached();
         if (externalConnection != null) {
             return externalConnection;
         }
 
-        var storage = getStorage(extensionContext);
-        var connection = storage.get(getConnectionType(), getConnectionType());
+        CallMode callMode = getCallMode(parameterContext);
+        Connection connection = getConnectionCurrent(extensionContext);
         if (connection != null) {
             return connection;
         } else {
-            var metadata = getMetadata(extensionContext);
+            Metadata metadata = getMetadata(extensionContext);
             if (metadata.runMode() == ContainerMode.PER_RUN || metadata.runMode() == ContainerMode.PER_CLASS) {
                 beforeAll(extensionContext);
             } else if (metadata.runMode() == ContainerMode.PER_METHOD) {
+                TestInstance.Lifecycle lifecycle = extensionContext.getTestInstanceLifecycle()
+                        .orElse(TestInstance.Lifecycle.PER_METHOD);
+                if (callMode == CallMode.CONSTRUCTOR && lifecycle == TestInstance.Lifecycle.PER_CLASS) {
+                    throw new ParameterResolutionException(String.format(
+                            "@%s can't be injected into constructor parameter when ContainerMode.%s is used and lifecycle is @%s",
+                            getConnectionAnnotation().getSimpleName(), ContainerMode.PER_METHOD,
+                            TestInstance.Lifecycle.PER_CLASS));
+                } else if (callMode == CallMode.BEFORE_ALL) {
+                    throw new ParameterResolutionException(
+                            String.format("@%s can't be injected into @%s method parameter when ContainerMode.%s is used",
+                                    getConnectionAnnotation().getSimpleName(), BeforeAll.class.getSimpleName(),
+                                    ContainerMode.PER_METHOD));
+                }
+
                 beforeEach(extensionContext);
             }
 
-            return Optional.ofNullable(storage.get(getConnectionType(), getConnectionType()))
-                    .orElseThrow(() -> new ExtensionConfigurationException(String.format(
+            return Optional.ofNullable(getConnectionCurrent(extensionContext))
+                    .orElseThrow(() -> new ParameterResolutionException(String.format(
                             "Parameter named '%s' with type '%s' can't be resolved cause it probably isn't initialized yet, please check extension annotation execution order",
                             parameterContext.getParameter().getName(), getConnectionType())));
         }
     }
 
-    private void setupBeforeAll(ExtensionContext context) {
-        var externalConnection = getConnectionExternalCached();
+    private CallMode getCallMode(ParameterContext parameterContext) {
+        if (parameterContext.getDeclaringExecutable().isAnnotationPresent(BeforeAll.class)) {
+            return CallMode.BEFORE_ALL;
+        } else if (parameterContext.getDeclaringExecutable().isAnnotationPresent(BeforeEach.class)) {
+            return CallMode.BEFORE_EACH;
+        } else if (parameterContext.getDeclaringExecutable().getDeclaringClass().getName()
+                .equals(parameterContext.getDeclaringExecutable().getName())) {
+            return CallMode.CONSTRUCTOR;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        final Connection externalConnection = getConnectionExternalCached();
+        final Metadata metadata = getMetadata(context);
+        final ExtensionContext.Store storage = getStorage(context);
         if (externalConnection == null) {
-            var metadata = getMetadata(context);
-            if (metadata.runMode() == ContainerMode.PER_RUN) {
-                var storage = getStorage(context);
-                var storageConnection = getConnectionCurrent(context);
-                if (storageConnection == null) {
-                    var containerFromField = getContainerFromField(context);
-                    var imageShared = containerFromField
-                            .map(GenericContainer::getDockerImageName)
-                            .orElseGet(metadata::image);
+            final Connection storageConnection = getConnectionCurrent(context);
+            if (storageConnection == null) {
+                if (metadata.runMode() == ContainerMode.PER_RUN) {
+                    final Optional<Container> containerFromField = getContainerFromField(context);
+                    final SharedKey sharedKey = containerFromField
+                            .map(c -> ((SharedKey) new SharedContainerInstance(c)))
+                            .orElseGet(() -> {
+                                final String imageShared = metadata.image();
+                                final Boolean networkShared = containerFromField.filter(c -> c.getNetwork() != null)
+                                        .map(c -> c.getNetwork() == Network.SHARED)
+                                        .orElse(metadata.networkShared());
 
-                    var networkShared = containerFromField.filter(c -> c.getNetwork() != null)
-                            .map(c -> c.getNetwork() == Network.SHARED)
-                            .orElse(metadata.networkShared());
+                                final String networkAlias = containerFromField.map(c -> c.getNetworkAliases())
+                                        .filter(a -> !a.isEmpty())
+                                        .map(a -> a.stream()
+                                                .filter(alias -> alias.equals(metadata.networkAlias()))
+                                                .findFirst()
+                                                .orElse(a.get(0)))
+                                        .orElse(metadata.networkAlias());
 
-                    var networkAlias = containerFromField.map(c -> c.getNetworkAliases())
-                            .filter(a -> !a.isEmpty())
-                            .map(a -> a.stream()
-                                    .filter(alias -> alias.equals(metadata.networkAlias()))
-                                    .findFirst()
-                                    .orElse(a.get(0)))
-                            .orElse(metadata.networkAlias());
+                                return new SharedContainerKey(imageShared, networkShared, networkAlias);
+                            });
 
-                    var sharedKey = new SharedKey(imageShared, networkShared, networkAlias);
-                    var sharedContainerMap = CLASS_TO_SHARED_CONTAINERS.computeIfAbsent(getClass().getCanonicalName(),
+                    var sharedContainerMap = CLASS_TO_SHARED_CONTAINERS.computeIfAbsent(
+                            getClass().getCanonicalName(),
                             k -> new ConcurrentHashMap<>());
 
                     var extensionContainer = sharedContainerMap.computeIfAbsent(sharedKey, k -> {
-                        var container = containerFromField.orElseGet(() -> {
+                        Container container = containerFromField.orElseGet(() -> {
                             logger.debug("Getting default container for image: {}", metadata.image());
                             return getContainerDefault(metadata);
                         });
@@ -288,18 +355,15 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
                         container.withReuse(true).start();
                         logger.info("Started in mode '{}' container: {}", metadata.runMode(),
                                 container.getDockerImageName());
-                        var connection = getConnectionForContainer(metadata, container);
+                        Connection connection = getConnectionForContainer(metadata, container);
                         return getExtensionContainer(container, connection);
                     });
 
                     storage.put(metadata.runMode(), extensionContainer);
                     storage.put(getConnectionType(), extensionContainer.connection());
-                }
-            } else if (metadata.runMode() == ContainerMode.PER_CLASS) {
-                var storage = getStorage(context);
-                var storageConnection = storage.get(getConnectionType(), getConnectionType());
-                if (storageConnection == null) {
-                    var container = getContainerFromField(context).orElseGet(() -> {
+                    injectConnection((Connection) extensionContainer.connection(), context);
+                } else if (metadata.runMode() == ContainerMode.PER_CLASS) {
+                    Container container = getContainerFromField(context).orElseGet(() -> {
                         logger.debug("Getting default container for image: {}", metadata.image());
                         return getContainerDefault(metadata);
                     });
@@ -307,53 +371,53 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
                     logger.debug("Starting in mode '{}' container: {}", metadata.runMode(), container.getDockerImageName());
                     container.start();
                     logger.info("Started in mode '{}' container: {}", metadata.runMode(), container.getDockerImageName());
-                    var connection = getConnectionForContainer(metadata, container);
-                    var extensionContainer = getExtensionContainer(container, connection);
+                    Connection connection = getConnectionForContainer(metadata, container);
+                    ExtensionContainer<Container, Connection> extensionContainer = getExtensionContainer(container, connection);
                     storage.put(metadata.runMode(), extensionContainer);
                     storage.put(getConnectionType(), connection);
+                    injectConnection(connection, context);
                 }
             }
         } else {
-            var storage = getStorage(context);
-            storage.put(getConnectionType(), externalConnection);
-        }
-    }
-
-    private void setupBeforeEach(ExtensionContext context) {
-        var externalConnection = getConnectionExternalCached();
-        if (externalConnection == null) {
-            var storage = getStorage(context);
-            var metadata = getMetadata(context);
-            if (metadata.runMode() == ContainerMode.PER_METHOD) {
-                var storageConnection = storage.get(getConnectionType(), getConnectionType());
-                if (storageConnection == null) {
-                    var container = getContainerFromField(context).orElseGet(() -> {
-                        logger.debug("Getting default container for image: {}", metadata.image());
-                        return getContainerDefault(metadata);
-                    });
-
-                    logger.debug("Starting in mode '{}' container: {}", metadata.runMode(), container.getDockerImageName());
-                    container.start();
-                    logger.info("Started in mode '{}' container: {}", metadata.runMode(), container.getDockerImageName());
-                    var connection = getConnectionForContainer(metadata, container);
-                    var extensionContainer = getExtensionContainer(container, connection);
-                    storage.put(metadata.runMode(), extensionContainer);
-                    storage.put(getConnectionType(), connection);
-                }
-            }
-        } else {
-            var storage = getStorage(context);
             storage.put(getConnectionType(), externalConnection);
         }
     }
 
     @Override
-    public void beforeAll(ExtensionContext context) {
-        setupBeforeAll(context);
+    public void beforeEach(ExtensionContext context) {
+        Connection externalConnection = getConnectionExternalCached();
+        Metadata metadata = getMetadata(context);
+        ExtensionContext.Store storage = getStorage(context);
+        if (externalConnection == null) {
+            Connection storageConnection = getConnectionCurrent(context);
+            if (storageConnection == null) {
+                if (metadata.runMode() == ContainerMode.PER_METHOD) {
+                    Container container = getContainerFromField(context).orElseGet(() -> {
+                        logger.debug("Getting default container for image: {}", metadata.image());
+                        return getContainerDefault(metadata);
+                    });
 
-        var metadata = getMetadata(context);
-        if (metadata.runMode() == ContainerMode.PER_RUN || metadata.runMode() == ContainerMode.PER_CLASS) {
-            var connection = getConnectionCurrent(context);
+                    logger.debug("Starting in mode '{}' container: {}", metadata.runMode(), container.getDockerImageName());
+                    container.start();
+                    logger.info("Started in mode '{}' container: {}", metadata.runMode(), container.getDockerImageName());
+                    Connection connection = getConnectionForContainer(metadata, container);
+                    ExtensionContainer<Container, Connection> extensionContainer = getExtensionContainer(container, connection);
+                    storage.put(metadata.runMode(), extensionContainer);
+                    storage.put(getConnectionType(), connection);
+                }
+            }
+        } else {
+            storage.put(getConnectionType(), externalConnection);
+        }
+
+        TestInstance.Lifecycle lifecycle = context.getTestInstanceLifecycle().orElse(TestInstance.Lifecycle.PER_METHOD);
+        if (lifecycle == TestInstance.Lifecycle.PER_METHOD) {
+            Connection connection = getConnectionCurrent(context);
+            if (connection != null) {
+                injectConnection(connection, context);
+            }
+        } else if (metadata.runMode() == ContainerMode.PER_METHOD) {
+            Connection connection = getConnectionCurrent(context);
             if (connection != null) {
                 injectConnection(connection, context);
             }
@@ -361,22 +425,12 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
     }
 
     @Override
-    public void beforeEach(ExtensionContext context) {
-        setupBeforeEach(context);
-
-        var connection = getConnectionCurrent(context);
-        if (connection != null) {
-            injectConnection(connection, context);
-        }
-    }
-
-    @Override
     public void afterEach(ExtensionContext context) {
-        var externalConnection = getConnectionExternalCached();
+        Connection externalConnection = getConnectionExternalCached();
         if (externalConnection == null) {
-            var metadata = getMetadata(context);
+            Metadata metadata = getMetadata(context);
             if (metadata.runMode() == ContainerMode.PER_METHOD) {
-                var storage = getStorage(context);
+                ExtensionContext.Store storage = getStorage(context);
                 final ExtensionContainer<Container, Connection> extensionContainer = storage.get(metadata.runMode(),
                         ExtensionContainer.class);
                 if (extensionContainer != null) {
@@ -395,9 +449,9 @@ public abstract class AbstractTestcontainersExtension<Connection, Container exte
 
     @Override
     public void afterAll(ExtensionContext context) {
-        var externalConnection = getConnectionExternalCached();
-        var storage = getStorage(context);
-        var metadata = getMetadata(context);
+        Connection externalConnection = getConnectionExternalCached();
+        ExtensionContext.Store storage = getStorage(context);
+        Metadata metadata = getMetadata(context);
         if (externalConnection == null) {
             if (metadata.runMode() == ContainerMode.PER_CLASS) {
                 final ExtensionContainer<Container, Connection> extensionContainer = storage.get(metadata.runMode(),

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerClassAbstractTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerClassAbstractTests.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@TestcontainersRedis(mode = ContainerMode.PER_CLASS, image = "redis:7.2-alpine")
+@TestcontainersRedis(mode = ContainerMode.PER_CLASS)
 abstract class ContainerPerClassAbstractTests {
 
     @ContainerRedisConnection

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerClassBeforeTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerClassBeforeTests.java
@@ -1,0 +1,58 @@
+package io.goodforgod.testcontainers.extensions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.goodforgod.testcontainers.extensions.example.ContainerRedisConnection;
+import io.goodforgod.testcontainers.extensions.example.RedisConnection;
+import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
+import org.junit.jupiter.api.*;
+
+@TestcontainersRedis(mode = ContainerMode.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ContainerPerClassBeforeTests {
+
+    private static RedisConnection setupAll;
+    private static RedisConnection setupEach;
+    private static RedisConnection setupFirst;
+
+    @ContainerRedisConnection
+    private RedisConnection fieldConnection;
+
+    @BeforeAll
+    public static void setupAll(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        setupAll = paramConnection;
+    }
+
+    @BeforeEach
+    public void setupEach(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertEquals(fieldConnection, paramConnection);
+        setupEach = paramConnection;
+    }
+
+    @Order(1)
+    @Test
+    void firstConnection(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        assertNotNull(fieldConnection);
+        assertEquals(fieldConnection, paramConnection);
+        assertEquals(setupAll, paramConnection);
+        assertEquals(setupEach, paramConnection);
+        setupFirst = paramConnection;
+    }
+
+    @Order(2)
+    @Test
+    void secondConnection(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        assertNotNull(fieldConnection);
+        assertEquals(fieldConnection, paramConnection);
+        assertEquals(setupAll, paramConnection);
+        assertEquals(setupEach, paramConnection);
+        assertEquals(setupFirst, paramConnection);
+    }
+}

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerClassConstructorTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerClassConstructorTests.java
@@ -8,7 +8,6 @@ import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
 import org.junit.jupiter.api.*;
 
 @TestcontainersRedis(mode = ContainerMode.PER_CLASS,
-        image = "redis:7.2-alpine",
         network = @Network(shared = false, alias = "my_alias"))
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodBeforeTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodBeforeTests.java
@@ -1,0 +1,47 @@
+package io.goodforgod.testcontainers.extensions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.goodforgod.testcontainers.extensions.example.ContainerRedisConnection;
+import io.goodforgod.testcontainers.extensions.example.RedisConnection;
+import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
+import org.junit.jupiter.api.*;
+
+@TestcontainersRedis(mode = ContainerMode.PER_METHOD)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ContainerPerMethodBeforeTests {
+
+    private static RedisConnection setupEach;
+    private static RedisConnection setupFirst;
+
+    @ContainerRedisConnection
+    private RedisConnection fieldConnection;
+
+    @BeforeEach
+    public void setupEach(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertEquals(fieldConnection, paramConnection);
+        setupEach = paramConnection;
+    }
+
+    @Order(1)
+    @Test
+    void firstConnection(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        assertNotNull(fieldConnection);
+        assertEquals(fieldConnection, paramConnection);
+        assertEquals(setupEach, paramConnection);
+        setupFirst = paramConnection;
+    }
+
+    @Order(2)
+    @Test
+    void secondConnection(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        assertNotNull(fieldConnection);
+        assertEquals(fieldConnection, paramConnection);
+        assertEquals(setupEach, paramConnection);
+        assertNotEquals(setupFirst, paramConnection);
+    }
+}

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodConstructorTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodConstructorTests.java
@@ -7,7 +7,7 @@ import io.goodforgod.testcontainers.extensions.example.RedisConnection;
 import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
 import org.junit.jupiter.api.*;
 
-@TestcontainersRedis(mode = ContainerMode.PER_METHOD, image = "redis:7.2-alpine")
+@TestcontainersRedis(mode = ContainerMode.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class ContainerPerMethodConstructorTests {

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodInstanceClassTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodInstanceClassTests.java
@@ -7,7 +7,7 @@ import io.goodforgod.testcontainers.extensions.example.RedisConnection;
 import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
 import org.junit.jupiter.api.*;
 
-@TestcontainersRedis(mode = ContainerMode.PER_METHOD, image = "redis:7.2-alpine")
+@TestcontainersRedis(mode = ContainerMode.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ContainerPerMethodInstanceClassTests {

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodInstanceMethodTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerMethodInstanceMethodTests.java
@@ -7,7 +7,7 @@ import io.goodforgod.testcontainers.extensions.example.RedisConnection;
 import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
 import org.junit.jupiter.api.*;
 
-@TestcontainersRedis(mode = ContainerMode.PER_METHOD, image = "redis:7.2-alpine")
+@TestcontainersRedis(mode = ContainerMode.PER_METHOD)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @TestInstance(TestInstance.Lifecycle.PER_METHOD)
 class ContainerPerMethodInstanceMethodTests {

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerRunBeforeTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerRunBeforeTests.java
@@ -1,0 +1,57 @@
+package io.goodforgod.testcontainers.extensions;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.goodforgod.testcontainers.extensions.example.ContainerRedisConnection;
+import io.goodforgod.testcontainers.extensions.example.RedisConnection;
+import io.goodforgod.testcontainers.extensions.example.TestcontainersRedis;
+import org.junit.jupiter.api.*;
+
+@TestcontainersRedis(mode = ContainerMode.PER_RUN, image = "redis:7.2.0-alpine")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class ContainerPerRunBeforeTests {
+
+    private static RedisConnection setupAll;
+    private static RedisConnection setupEach;
+    private static RedisConnection setupFirst;
+
+    @ContainerRedisConnection
+    private RedisConnection fieldConnection;
+
+    @BeforeAll
+    public static void setupAll(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        setupAll = paramConnection;
+    }
+
+    @BeforeEach
+    public void setupEach(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertEquals(fieldConnection, paramConnection);
+        setupEach = paramConnection;
+    }
+
+    @Order(1)
+    @Test
+    void firstConnection(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        assertNotNull(fieldConnection);
+        assertEquals(fieldConnection, paramConnection);
+        assertEquals(setupAll, paramConnection);
+        assertEquals(setupEach, paramConnection);
+        setupFirst = paramConnection;
+    }
+
+    @Order(2)
+    @Test
+    void secondConnection(@ContainerRedisConnection RedisConnection paramConnection) {
+        assertNotNull(paramConnection);
+        assertNotNull(paramConnection.params().uri());
+        assertNotNull(fieldConnection);
+        assertEquals(fieldConnection, paramConnection);
+        assertEquals(setupAll, paramConnection);
+        assertEquals(setupEach, paramConnection);
+        assertEquals(setupFirst, paramConnection);
+    }
+}

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerRunFirstTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerRunFirstTests.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@TestcontainersRedis(mode = ContainerMode.PER_RUN, image = "redis:7.2-alpine")
+@TestcontainersRedis(mode = ContainerMode.PER_RUN)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ContainerPerRunFirstTests {
 

--- a/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerRunSecondTests.java
+++ b/common/src/test/java/io/goodforgod/testcontainers/extensions/ContainerPerRunSecondTests.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
-@TestcontainersRedis(mode = ContainerMode.PER_RUN, image = "redis:7.2-alpine")
+@TestcontainersRedis(mode = ContainerMode.PER_RUN)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ContainerPerRunSecondTests {
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -7,7 +7,7 @@ dependencyResolutionManagement { DependencyResolutionManagement it ->
             version("junit-api", "5.9.3")
             version("junit-platform", "1.9.3")
             version("testcontainers", "1.17.6")
-            version("flyway", "9.20.1")
+            version("flyway", "9.21.2")
             version("liquibase", "4.23.1")
 
             library("slf4j-api", "org.slf4j", "slf4j-api").versionRef("slf4j")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 groupId=io.goodforgod
 artifactRootId=testcontainers-extensions
-artifactVersion=0.7.0-SNAPSHOT
+artifactVersion=0.8.0-SNAPSHOT
 
 
 ##### GRADLE #####

--- a/jdbc/README.md
+++ b/jdbc/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-jdbc/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-jdbc)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)

--- a/jdbc/src/main/java/io/goodforgod/testcontainers/extensions/jdbc/AbstractTestcontainersJdbcExtension.java
+++ b/jdbc/src/main/java/io/goodforgod/testcontainers/extensions/jdbc/AbstractTestcontainersJdbcExtension.java
@@ -1,6 +1,7 @@
 package io.goodforgod.testcontainers.extensions.jdbc;
 
 import io.goodforgod.testcontainers.extensions.AbstractTestcontainersExtension;
+import io.goodforgod.testcontainers.extensions.ContainerMode;
 import java.io.FileWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -16,6 +17,7 @@ import liquibase.exception.LiquibaseException;
 import liquibase.resource.ClassLoaderResourceAccessor;
 import org.flywaydb.core.Flyway;
 import org.jetbrains.annotations.ApiStatus.Internal;
+import org.junit.jupiter.api.extension.ExtensionConfigurationException;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 import org.testcontainers.containers.JdbcDatabaseContainer;
@@ -160,19 +162,29 @@ abstract class AbstractTestcontainersJdbcExtension<Container extends JdbcDatabas
         super.beforeAll(context);
 
         var metadata = getMetadata(context);
-        var connectionCurrent = getConnectionCurrent(context);
-        if (metadata.migration().apply() == Migration.Mode.PER_CLASS) {
+        if (metadata.migration().apply() != Migration.Mode.NONE) {
+            var storage = getStorage(context);
+            var connectionCurrent = getConnectionCurrent(context);
             tryMigrateIfRequired(metadata, connectionCurrent);
+            storage.put(Migration.class, metadata.migration().apply());
         }
     }
 
     @Override
     public void beforeEach(ExtensionContext context) {
+        var metadata = getMetadata(context);
+        if (metadata.runMode() == ContainerMode.PER_METHOD && metadata.migration().apply() == Migration.Mode.PER_CLASS) {
+            throw new ExtensionConfigurationException(String.format(
+                    "@%s can't apply migration in Migration.Mode.PER_CLASS mode when ContainerMode.PER_METHOD is used",
+                    getContainerAnnotation().getSimpleName()));
+        }
+
         super.beforeEach(context);
 
-        var metadata = getMetadata(context);
-        var connectionCurrent = getConnectionCurrent(context);
-        if (metadata.migration().apply() == Migration.Mode.PER_METHOD) {
+        var storage = getStorage(context);
+        var mode = storage.get(Migration.class, Migration.Mode.class);
+        if (mode == null) {
+            var connectionCurrent = getConnectionCurrent(context);
             tryMigrateIfRequired(metadata, connectionCurrent);
         }
     }
@@ -180,9 +192,13 @@ abstract class AbstractTestcontainersJdbcExtension<Container extends JdbcDatabas
     @Override
     public void afterEach(ExtensionContext context) {
         var metadata = getMetadata(context);
-        var connectionCurrent = getConnectionCurrent(context);
+        var storage = getStorage(context);
+        storage.remove(Migration.class);
         if (metadata.migration().drop() == Migration.Mode.PER_METHOD) {
-            tryDropIfRequired(metadata, connectionCurrent);
+            if (metadata.runMode() != ContainerMode.PER_METHOD) {
+                var connectionCurrent = getConnectionCurrent(context);
+                tryDropIfRequired(metadata, connectionCurrent);
+            }
         }
 
         super.afterEach(context);
@@ -193,7 +209,9 @@ abstract class AbstractTestcontainersJdbcExtension<Container extends JdbcDatabas
         var metadata = getMetadata(context);
         var connectionCurrent = getConnectionCurrent(context);
         if (metadata.migration().drop() == Migration.Mode.PER_CLASS) {
-            tryDropIfRequired(metadata, connectionCurrent);
+            if (metadata.runMode() == ContainerMode.PER_RUN) {
+                tryDropIfRequired(metadata, connectionCurrent);
+            }
         }
 
         super.afterAll(context);

--- a/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerClassMigrationTests.java
+++ b/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerClassMigrationTests.java
@@ -19,11 +19,13 @@ class FlywayPerClassMigrationTests {
 
     @BeforeAll
     public static void setupAll(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM users;", r -> r.getInt(1));
         assertNotNull(paramConnection);
     }
 
     @BeforeEach
     public void setupEach(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM users;", r -> r.getInt(1));
         assertNotNull(paramConnection);
     }
 

--- a/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerClassMigrationTests.java
+++ b/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerClassMigrationTests.java
@@ -1,14 +1,12 @@
 package io.goodforgod.testcontainers.extensions.jdbc;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.goodforgod.testcontainers.extensions.ContainerMode;
 import io.goodforgod.testcontainers.extensions.jdbc.example.ContainerJdbcConnection;
 import io.goodforgod.testcontainers.extensions.jdbc.example.TestcontainersJdbc;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 
 @TestcontainersJdbc(mode = ContainerMode.PER_CLASS,
         image = "postgres:15.2-alpine",
@@ -18,6 +16,16 @@ import org.junit.jupiter.api.TestMethodOrder;
                 drop = Migration.Mode.PER_CLASS))
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class FlywayPerClassMigrationTests {
+
+    @BeforeAll
+    public static void setupAll(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        assertNotNull(paramConnection);
+    }
+
+    @BeforeEach
+    public void setupEach(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        assertNotNull(paramConnection);
+    }
 
     @Order(1)
     @Test

--- a/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerMethodMigrationTests.java
+++ b/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerMethodMigrationTests.java
@@ -19,11 +19,13 @@ class FlywayPerMethodMigrationTests {
 
     @BeforeAll
     public static void setupAll(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM users;", r -> r.getInt(1));
         assertNotNull(paramConnection);
     }
 
     @BeforeEach
     public void setupEach(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        paramConnection.queryOne("SELECT * FROM users;", r -> r.getInt(1));
         assertNotNull(paramConnection);
     }
 

--- a/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerMethodMigrationTests.java
+++ b/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/FlywayPerMethodMigrationTests.java
@@ -1,14 +1,12 @@
 package io.goodforgod.testcontainers.extensions.jdbc;
 
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.goodforgod.testcontainers.extensions.ContainerMode;
 import io.goodforgod.testcontainers.extensions.jdbc.example.ContainerJdbcConnection;
 import io.goodforgod.testcontainers.extensions.jdbc.example.TestcontainersJdbc;
-import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.*;
 
 @TestcontainersJdbc(mode = ContainerMode.PER_CLASS,
         image = "postgres:15.1-alpine",
@@ -18,6 +16,16 @@ import org.junit.jupiter.api.TestMethodOrder;
                 drop = Migration.Mode.PER_METHOD))
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class FlywayPerMethodMigrationTests {
+
+    @BeforeAll
+    public static void setupAll(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        assertNotNull(paramConnection);
+    }
+
+    @BeforeEach
+    public void setupEach(@ContainerJdbcConnection JdbcConnection paramConnection) {
+        assertNotNull(paramConnection);
+    }
 
     @Order(1)
     @Test

--- a/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/JdbcContainerFromAnnotationTests.java
+++ b/jdbc/src/test/java/io/goodforgod/testcontainers/extensions/jdbc/JdbcContainerFromAnnotationTests.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
 
 @TestcontainersJdbc(mode = ContainerMode.PER_METHOD, image = "postgres:15.2-alpine")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
@@ -20,11 +21,12 @@ class JdbcContainerFromAnnotationTests {
     private static final String CUSTOM = "user";
 
     @ContainerJdbc
-    private static final PostgreSQLContainer<?> container = new PostgreSQLContainer<>()
-            .withDatabaseName(CUSTOM)
-            .withUsername(CUSTOM)
-            .withPassword(CUSTOM)
-            .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(PostgreSQLContainer.class)));
+    private static final PostgreSQLContainer<?> container = new PostgreSQLContainer<>(
+            DockerImageName.parse("postgres:15.2-alpine"))
+                    .withDatabaseName(CUSTOM)
+                    .withUsername(CUSTOM)
+                    .withPassword(CUSTOM)
+                    .withLogConsumer(new Slf4jLogConsumer(LoggerFactory.getLogger(PostgreSQLContainer.class)));
 
     @Test
     void checkParams(@ContainerJdbcConnection JdbcConnection connection) {

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-kafka:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-kafka:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-kafka:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-kafka</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-kafka/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-kafka)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -66,7 +66,7 @@ testRuntimeOnly "org.apache.kafka:kafka-clients:3.5.1"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/kafka/src/main/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnection.java
+++ b/kafka/src/main/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnection.java
@@ -111,18 +111,6 @@ public interface KafkaConnection {
         void assertReceivedNone(@NotNull Duration timeToWait);
 
         /**
-         * @param timeout time to check that at least 1 event received in specified time
-         * @throws AssertionFailedError if received 0 event in specified time {@link Assertions#fail()}
-         */
-        @NotNull
-        ReceivedEvent assertReceivedAtLeast(@NotNull Duration timeout);
-
-        @NotNull
-        default ReceivedEvent assertReceivedAtLeast() {
-            return assertReceivedAtLeast(Duration.ofSeconds(15));
-        }
-
-        /**
          * @param expectedAtLeast number of expected events
          * @param timeout         time to check that at least N events received in specified time
          * @throws AssertionFailedError if received less than N event in specified time

--- a/kafka/src/main/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnectionImpl.java
+++ b/kafka/src/main/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnectionImpl.java
@@ -425,7 +425,7 @@ final class KafkaConnectionImpl implements KafkaConnection {
 
     private static KafkaConsumer<byte[], byte[]> getConsumer(Properties properties) {
         final Properties consumerProperties = new Properties();
-        final String id = "testcontainers-kafka-" + UUID.randomUUID().toString().substring(0, 9);
+        final String id = "testcontainers-kafka-" + UUID.randomUUID().toString().substring(0, 8);
         consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
         consumerProperties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
         consumerProperties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "5");

--- a/kafka/src/main/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnectionImpl.java
+++ b/kafka/src/main/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnectionImpl.java
@@ -256,12 +256,6 @@ final class KafkaConnectionImpl implements KafkaConnection {
         }
 
         @Override
-        public @NotNull ReceivedEvent assertReceivedAtLeast(@NotNull Duration timeout) {
-            var received = getReceived(timeout);
-            return received.orElseGet(() -> Assertions.fail("Expected to receive 1 event, but received 0 event"));
-        }
-
-        @Override
         public @NotNull List<ReceivedEvent> assertReceivedAtLeast(int expectedAtLeast, @NotNull Duration timeout) {
             final List<ReceivedEvent> received = getReceivedAtLeast(expectedAtLeast, timeout);
             if (received.size() < expectedAtLeast) {

--- a/kafka/src/test/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnectionAssertsTests.java
+++ b/kafka/src/test/java/io/goodforgod/testcontainers/extensions/kafka/KafkaConnectionAssertsTests.java
@@ -81,7 +81,7 @@ class KafkaConnectionAssertsTests {
         var topic = "example";
         var consumer = connection.subscribe(topic);
         connection.send(topic, Event.builder().withValue("value").withHeader("1", "1").build());
-        var receivedEvent = consumer.assertReceivedAtLeast(Duration.ofSeconds(1));
+        var receivedEvent = consumer.assertReceivedAtLeast(1, Duration.ofSeconds(1));
         assertNotNull(receivedEvent.toString());
     }
 
@@ -89,7 +89,7 @@ class KafkaConnectionAssertsTests {
     void assertReceivedThrows() {
         var topic = "example";
         var consumer = connection.subscribe(topic);
-        assertThrows(AssertionFailedError.class, () -> consumer.assertReceivedAtLeast(Duration.ofSeconds(1)));
+        assertThrows(AssertionFailedError.class, () -> consumer.assertReceivedAtLeast(1, Duration.ofSeconds(1)));
     }
 
     @Test

--- a/kafka/src/test/java/io/goodforgod/testcontainers/extensions/kafka/KafkaContainerPerMethodConstructorTests.java
+++ b/kafka/src/test/java/io/goodforgod/testcontainers/extensions/kafka/KafkaContainerPerMethodConstructorTests.java
@@ -5,26 +5,18 @@ import static org.junit.jupiter.api.Assertions.*;
 import io.goodforgod.testcontainers.extensions.ContainerMode;
 import org.junit.jupiter.api.*;
 
-@TestcontainersKafka(mode = ContainerMode.PER_CLASS, topics = @Topics(value = "my-topic"))
+@TestcontainersKafka(mode = ContainerMode.PER_METHOD, topics = @Topics(value = "my-topic"))
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
-class KafkaContainerPerClassConstructorTests {
+@TestInstance(TestInstance.Lifecycle.PER_METHOD)
+class KafkaContainerPerMethodConstructorTests {
 
     private final KafkaConnection sameConnection;
 
     private static KafkaConnection firstConnection;
 
-    KafkaContainerPerClassConstructorTests(@ContainerKafkaConnection KafkaConnection sameConnection) {
+    KafkaContainerPerMethodConstructorTests(@ContainerKafkaConnection KafkaConnection sameConnection) {
         this.sameConnection = sameConnection;
         assertNotNull(sameConnection);
-    }
-
-    @BeforeAll
-    public static void setupAll(@ContainerKafkaConnection KafkaConnection paramConnection) {
-        var consumer = paramConnection.subscribe("my-topic");
-        paramConnection.send("my-topic", Event.ofValue("my-value"));
-        consumer.assertReceivedAtLeast(1);
-        assertNotNull(paramConnection);
     }
 
     @BeforeEach
@@ -52,6 +44,6 @@ class KafkaContainerPerClassConstructorTests {
         assertNotNull(firstConnection);
         assertNotNull(sameConnection);
         assertEquals(sameConnection, connection);
-        assertEquals(firstConnection, connection);
+        assertNotEquals(firstConnection, connection);
     }
 }

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-mariadb/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-mariadb)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -63,7 +63,7 @@ testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:3.1.4"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/mariadb/README.md
+++ b/mariadb/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-mariadb:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-mariadb:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-mariadb:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-mariadb</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/mockserver/README.md
+++ b/mockserver/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuRpp.com/maven-central/io.goodforgod/testcontainers-extensions-mockserver/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-mockserver)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -43,7 +43,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-mockserver:0.7.0"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/mockserver/README.md
+++ b/mockserver/README.md
@@ -17,7 +17,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-mockserver:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-mockserver:0.8.0"
 ```
 
 **Maven**
@@ -25,7 +25,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-mockserver:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-mockserver</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/mockserver/src/main/java/io/goodforgod/testcontainers/extensions/mockserver/MockserverConnectionImpl.java
+++ b/mockserver/src/main/java/io/goodforgod/testcontainers/extensions/mockserver/MockserverConnectionImpl.java
@@ -43,6 +43,7 @@ final class MockserverConnectionImpl implements MockserverConnection {
 
     private final Params params;
     private final Params network;
+
     private final MockServerClient client;
 
     MockserverConnectionImpl(Params params, Params network) {

--- a/mockserver/src/main/java/io/goodforgod/testcontainers/extensions/mockserver/TestcontainersMockserverExtension.java
+++ b/mockserver/src/main/java/io/goodforgod/testcontainers/extensions/mockserver/TestcontainersMockserverExtension.java
@@ -102,9 +102,9 @@ class TestcontainersMockserverExtension extends
 
     @Override
     public void afterEach(ExtensionContext context) {
-        super.afterEach(context);
-
         var connection = getConnectionCurrent(context);
         connection.client().reset();
+
+        super.afterEach(context);
     }
 }

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-mysql/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-mysql)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -63,7 +63,7 @@ testRuntimeOnly "mysql:mysql-connector-java:8.0.33"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-mysql:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-mysql:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-mysql:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-mysql</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-oracle:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-oracle:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-oracle:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-oracle</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-oracle/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-oracle)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -66,7 +66,7 @@ Extension tested against image `gvenzl/oracle-xe:18.4.0-faststart` and driver `c
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-postgres/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-postgres)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -63,7 +63,7 @@ testRuntimeOnly "org.postgresql:postgresql:42.6.0"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -18,7 +18,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-postgres:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-postgres:0.8.0"
 ```
 
 **Maven**
@@ -26,7 +26,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-postgres:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-postgres</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/redis/README.md
+++ b/redis/README.md
@@ -17,7 +17,7 @@ Features:
 
 **Gradle**
 ```groovy
-testImplementation "io.goodforgod:testcontainers-extensions-redis:0.7.0"
+testImplementation "io.goodforgod:testcontainers-extensions-redis:0.8.0"
 ```
 
 **Maven**
@@ -25,7 +25,7 @@ testImplementation "io.goodforgod:testcontainers-extensions-redis:0.7.0"
 <dependency>
     <groupId>io.goodforgod</groupId>
     <artifactId>testcontainers-extensions-redis</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
     <scope>test</scope>
 </dependency>
 ```

--- a/redis/README.md
+++ b/redis/README.md
@@ -2,7 +2,7 @@
 
 [![Minimum required Java version](https://img.shields.io/badge/Java-11%2B-blue?logo=openjdk)](https://openjdk.org/projects/jdk/11/)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-redis/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.goodforgod/testcontainers-extensions-redis)
-[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=CI+Master)
+[![GitHub Action](https://github.com/goodforgod/testcontainers-extensions/workflows/Release/badge.svg)](https://github.com/GoodforGod/testcontainers-extensions/actions?query=workflow%3A"CI+Master"++)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=coverage)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
 [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=GoodforGod_testcontainers-extensions&metric=ncloc)](https://sonarcloud.io/dashboard?id=GoodforGod_testcontainers-extensions)
@@ -62,7 +62,7 @@ testImplementation "redis.clients:jedis:4.4.3"
 
 Available containers modes:
 
-- `PER_RUN` - start container one time per *test execution*. (Containers must have same `image` and `network` to be reused between test classes)
+- `PER_RUN` - start container one time per *test execution*. (Containers must have same instance, e.g. compare by `==`)
 - `PER_CLASS` - start new container each *test class*.
 - `PER_METHOD` - start new container each *test method*.
 


### PR DESCRIPTION
Features:
- AbstractTestcontainersJdbcExtension migration for constructor & parameter injection fixed
- TestcontainersCassandraExtension migration for constructor & parameter injection fixed
- TestcontainersKafkaExtension topics reset & setup for constructor & parameter injection fixed
- TestcontainersKafkaExtension close connection before container stopped fixed
- AbstractTestcontainersExtension shared per run container now requires container same instance
- AbstractTestcontainersExtension & other extensions illegal parameters composition fails added
- TestcontainersMockserverExtension reset fixed
- KafkaConnection#assertReceivedAtLeast without count removed
- Tests reinforced
- Migration & Topics setup optimizations
- CassandraConnection#get fixed and potential closing handling added
- Flyway updated
- Tests reinforced